### PR TITLE
Add color-coded screen time

### DIFF
--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -188,22 +188,34 @@ export default function Dashboard() {
   // Helpers to color code screen time
   const getDailyColor = (minutes: number) => {
     const hours = minutes / 60;
-    if (hours > 5) return '#ef4444';
-    if (hours < 2) return '#10b981';
-    return '#f59e0b';
+    if (hours <= 2) {
+      return '#10b981';
+    }
+    if (hours < 5) {
+      return '#f59e0b';
+    }
+    return '#ef4444';
   };
 
   const getWeekColor = (minutes: number) => {
     const hours = minutes / 60;
-    if (hours > 35) return '#ef4444';
-    if (hours < 20) return '#10b981';
-    return '#f59e0b';
+    if (hours <= 20) {
+      return '#10b981';
+    }
+    if (hours <= 35) {
+      return '#f59e0b';
+    }
+    return '#ef4444';
   };
 
   // Screen time visualization using updated thresholds
   const getScreenTimeStatus = () => {
-    if (screenTimeInfo.todayScreenTime < 120) return { color: '#10b981', emoji: '🟢', status: 'Great!' };
-    if (screenTimeInfo.todayScreenTime < 300) return { color: '#f59e0b', emoji: '🟠', status: 'Moderate' };
+    if (screenTimeInfo.todayScreenTime <= 120) {
+      return { color: '#10b981', emoji: '🟢', status: 'Great!' };
+    }
+    if (screenTimeInfo.todayScreenTime < 300) {
+      return { color: '#f59e0b', emoji: '🟠', status: 'Moderate' };
+    }
     return { color: '#ef4444', emoji: '🔴', status: 'High' };
   };
 

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -185,10 +185,25 @@ export default function Dashboard() {
 
   const currentStats = getCurrentStats();
 
-  // Screen time visualization
+  // Helpers to color code screen time
+  const getDailyColor = (minutes: number) => {
+    const hours = minutes / 60;
+    if (hours > 5) return '#ef4444';
+    if (hours < 2) return '#10b981';
+    return '#f59e0b';
+  };
+
+  const getWeekColor = (minutes: number) => {
+    const hours = minutes / 60;
+    if (hours > 35) return '#ef4444';
+    if (hours < 20) return '#10b981';
+    return '#f59e0b';
+  };
+
+  // Screen time visualization using updated thresholds
   const getScreenTimeStatus = () => {
     if (screenTimeInfo.todayScreenTime < 120) return { color: '#10b981', emoji: '🟢', status: 'Great!' };
-    if (screenTimeInfo.todayScreenTime < 240) return { color: '#f59e0b', emoji: '🟡', status: 'Moderate' };
+    if (screenTimeInfo.todayScreenTime < 300) return { color: '#f59e0b', emoji: '🟠', status: 'Moderate' };
     return { color: '#ef4444', emoji: '🔴', status: 'High' };
   };
 
@@ -353,17 +368,17 @@ export default function Dashboard() {
                       <Text style={styles.chartDay}>Today</Text>
                     </View>
                     <View style={styles.chartBarContainer}>
-                      <View 
+                      <View
                         style={[
-                          styles.chartBarFill, 
-                          { 
+                          styles.chartBarFill,
+                          {
                             height: Math.min((screenTimeInfo.todayScreenTime / 480) * 40, 40),
-                            backgroundColor: screenTimeStatus.color 
+                            backgroundColor: getDailyColor(screenTimeInfo.todayScreenTime)
                           }
-                        ]} 
+                        ]}
                       />
                     </View>
-                    <Text style={styles.chartValue}>
+                    <Text style={[styles.chartValue, { color: getDailyColor(screenTimeInfo.todayScreenTime) }]}>
                       {Math.floor(screenTimeInfo.todayScreenTime / 60)}h
                     </Text>
                   </View>
@@ -373,17 +388,17 @@ export default function Dashboard() {
                       <Text style={styles.chartDay}>Yesterday</Text>
                     </View>
                     <View style={styles.chartBarContainer}>
-                      <View 
+                      <View
                         style={[
-                          styles.chartBarFill, 
-                          { 
+                          styles.chartBarFill,
+                          {
                             height: Math.min((screenTimeInfo.yesterdayScreenTime / 480) * 40, 40),
-                            backgroundColor: '#e5e7eb' 
+                            backgroundColor: getDailyColor(screenTimeInfo.yesterdayScreenTime)
                           }
-                        ]} 
+                        ]}
                       />
                     </View>
-                    <Text style={styles.chartValue}>
+                    <Text style={[styles.chartValue, { color: getDailyColor(screenTimeInfo.yesterdayScreenTime) }]}>
                       {Math.floor(screenTimeInfo.yesterdayScreenTime / 60)}h
                     </Text>
                   </View>
@@ -393,17 +408,17 @@ export default function Dashboard() {
                       <Text style={styles.chartDay}>Week Avg</Text>
                     </View>
                     <View style={styles.chartBarContainer}>
-                      <View 
+                      <View
                         style={[
-                          styles.chartBarFill, 
-                          { 
+                          styles.chartBarFill,
+                          {
                             height: Math.min(((screenTimeInfo.weekScreenTime / 7) / 480) * 40, 40),
-                            backgroundColor: '#a1a1aa' 
+                            backgroundColor: getWeekColor(screenTimeInfo.weekScreenTime)
                           }
-                        ]} 
+                        ]}
                       />
                     </View>
-                    <Text style={styles.chartValue}>
+                    <Text style={[styles.chartValue, { color: getWeekColor(screenTimeInfo.weekScreenTime) }]}>
                       {Math.floor((screenTimeInfo.weekScreenTime / 7) / 60)}h
                     </Text>
                   </View>


### PR DESCRIPTION
## Summary
- color code today's screen time with new 2h/5h thresholds
- show color coded bars for today, yesterday and week average

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68459870ac488322abdc303a12935ed6