### PR TITLE
Add Jest unit tests and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,16 @@ https://deepwiki.com/hiteshjoshi1/tracker/1-overview
 - Install dependencies with `npm install`.
 - Run tests with `npm test`.
 - Lint with `npm run lint`.
+
+### Running Tests
+Execute the unit test suite with:
+
+```bash
+npm test
+```
+
+For watch mode during development use:
+
+```bash
+npm run test:watch
+```

--- a/__tests__/habitService.test.ts
+++ b/__tests__/habitService.test.ts
@@ -1,0 +1,63 @@
+import { HabitService } from '../services/habitService';
+import { NotificationService } from '../services/notificationService';
+import { Habit } from '../models/types';
+
+jest.mock('../services/notificationService', () => {
+  return {
+    NotificationService: {
+      cancelHabitNotifications: jest.fn(),
+      scheduleHabitNotification: jest.fn()
+    },
+    __esModule: true,
+    default: {
+      cancelHabitNotifications: jest.fn(),
+      scheduleHabitNotification: jest.fn()
+    }
+  };
+});
+
+const mockHabit: Habit = {
+  id: '123',
+  userId: 'u1',
+  name: 'Test Habit',
+  status: 'untracked',
+  streak: 0,
+  longestStreak: 0,
+  lastCompleted: null,
+  date: new Date(),
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  completionHistory: {}
+};
+
+describe('HabitService.updateHabit', () => {
+  const habitService = new HabitService();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('schedules notifications when reminderTime changes', async () => {
+    jest.spyOn(habitService, 'getItemById').mockResolvedValue(mockHabit);
+    jest.spyOn(habitService, 'updateItem').mockResolvedValue();
+
+    const updates = { reminderTime: '08:00 AM' };
+    await habitService.updateHabit('123', updates);
+
+    expect(NotificationService.cancelHabitNotifications).toHaveBeenCalledWith('123');
+    expect(NotificationService.scheduleHabitNotification).toHaveBeenCalledWith({
+      ...mockHabit,
+      ...updates
+    });
+    expect(habitService.updateItem).toHaveBeenCalledWith('123', updates);
+  });
+
+  it('does not interact with notifications when no reminder fields', async () => {
+    jest.spyOn(habitService, 'updateItem').mockResolvedValue();
+    await habitService.updateHabit('123', { name: 'New Name' });
+
+    expect(NotificationService.cancelHabitNotifications).not.toHaveBeenCalled();
+    expect(NotificationService.scheduleHabitNotification).not.toHaveBeenCalled();
+    expect(habitService.updateItem).toHaveBeenCalledWith('123', { name: 'New Name' });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "test": "jest --watchAll",
+    "test": "jest",
+    "test:watch": "jest --watchAll",
     "lint": "expo lint"
   },
   "jest": {


### PR DESCRIPTION
## Summary
- add HabitService tests using Jest mocks
- expose npm test script without watch
- document how to run the tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596a1266e08322a3bb11ff80fa04c4